### PR TITLE
Fix menu item visibility to show only for Java packages

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+.idea/
+build/
+.gradle/

--- a/src/main/java/com/kenshoo/pl/intellij/codegen/ClassCreator.java
+++ b/src/main/java/com/kenshoo/pl/intellij/codegen/ClassCreator.java
@@ -4,7 +4,7 @@ import com.intellij.ide.fileTemplates.FileTemplate;
 import com.intellij.ide.fileTemplates.FileTemplateManager;
 import com.intellij.openapi.project.Project;
 import com.intellij.psi.JavaDirectoryService;
-import com.intellij.psi.impl.file.PsiJavaDirectoryImpl;
+import com.intellij.psi.PsiDirectory;
 
 import java.util.Collections;
 import java.util.Map;
@@ -17,7 +17,7 @@ public class ClassCreator {
     private static final String TEMPLATE_NAME = "PL Code Generator (internal)";
     private static final String TEMPLATE_CONTENT = "${CODE}";
 
-    public void generateClass(PsiJavaDirectoryImpl directory, String className, String code) {
+    public void generateClass(PsiDirectory directory, String className, String code) {
         final FileTemplate template = getOrCreateTemplate(directory.getProject());
         final Map<String, String> templateParameters = Collections.singletonMap("CODE", code);
         JavaDirectoryService.getInstance().createClass(directory, className, template.getName(), false, templateParameters);

--- a/src/main/java/com/kenshoo/pl/intellij/controller/NewEntityController.java
+++ b/src/main/java/com/kenshoo/pl/intellij/controller/NewEntityController.java
@@ -2,7 +2,7 @@ package com.kenshoo.pl.intellij.controller;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.CaseFormat;
-import com.intellij.psi.impl.file.PsiJavaDirectoryImpl;
+import com.intellij.psi.PsiDirectory;
 import com.kenshoo.pl.intellij.codegen.*;
 import com.kenshoo.pl.intellij.model.EntityInput;
 
@@ -51,7 +51,7 @@ public class NewEntityController {
         this.deleteCommandCodeGenerator = deleteCommandCodeGenerator;
     }
 
-    public void createNewEntity(PsiJavaDirectoryImpl directory, EntityInput input) {
+    public void createNewEntity(PsiDirectory directory, EntityInput input) {
         final String tableClassName = createTableClassName(input.getTableName());
         final String entityClassName = createEntityClassName(input.getEntityName());
         final String entityPersistenceClassName = createEntityPersistenceClassName(input.getEntityName());

--- a/src/main/java/com/kenshoo/pl/intellij/controller/PlEntityWizardAction.java
+++ b/src/main/java/com/kenshoo/pl/intellij/controller/PlEntityWizardAction.java
@@ -1,28 +1,56 @@
 package com.kenshoo.pl.intellij.controller;
 
-import com.intellij.openapi.actionSystem.AnAction;
-import com.intellij.openapi.actionSystem.AnActionEvent;
-import com.intellij.openapi.actionSystem.CommonDataKeys;
-import com.intellij.openapi.actionSystem.LangDataKeys;
-import com.intellij.pom.Navigatable;
-import com.intellij.psi.PsiFile;
-import com.intellij.psi.impl.file.PsiJavaDirectoryImpl;
+import com.intellij.ide.IdeView;
+import com.intellij.openapi.actionSystem.*;
+import com.intellij.openapi.roots.ProjectFileIndex;
+import com.intellij.openapi.roots.ProjectRootManager;
+import com.intellij.psi.PsiDirectory;
 import com.kenshoo.pl.intellij.view.NewEntityFormWrapper;
+import org.apache.commons.lang.ArrayUtils;
 import org.jetbrains.annotations.NotNull;
+
+import java.util.Optional;
 
 public class PlEntityWizardAction extends AnAction {
 
-  @Override
-  public void update(AnActionEvent e) {
-    final Navigatable navigatable = e.getData(CommonDataKeys.NAVIGATABLE);
-    e.getPresentation().setEnabledAndVisible(navigatable instanceof PsiJavaDirectoryImpl);
-  }
+    private final SourcePackageClassifier sourcePackageClassifier;
 
-  @Override
-  public void actionPerformed(@NotNull AnActionEvent e) {
-    final PsiJavaDirectoryImpl javaDirectory = (PsiJavaDirectoryImpl) e.getData(CommonDataKeys.NAVIGATABLE);
-    new NewEntityFormWrapper(javaDirectory).show();
-  }
+    public PlEntityWizardAction() {
+        this(new SourcePackageClassifier());
+    }
 
+    PlEntityWizardAction(final SourcePackageClassifier sourcePackageClassifier) {
+        this.sourcePackageClassifier = sourcePackageClassifier;
+    }
+
+    @Override
+    public void update(@NotNull AnActionEvent e) {
+        boolean available = isAvailable(e.getDataContext());
+        e.getPresentation().setEnabledAndVisible(available);
+    }
+
+    @Override
+    public void actionPerformed(@NotNull AnActionEvent e) {
+        Optional.ofNullable(LangDataKeys.IDE_VIEW.getData(e.getDataContext()))
+                .map(IdeView::getOrChooseDirectory)
+                .map(NewEntityFormWrapper::new)
+                .ifPresent(NewEntityFormWrapper::show);
+    }
+
+    private boolean isAvailable(DataContext dataContext) {
+        final Optional<ProjectFileIndex> optionalProjectFileIndex =
+            Optional.ofNullable(CommonDataKeys.PROJECT.getData(dataContext))
+                    .map(ProjectRootManager::getInstance)
+                    .map(ProjectRootManager::getFileIndex);
+
+        final Optional<PsiDirectory[]> optionalDirs =
+            Optional.ofNullable(LangDataKeys.IDE_VIEW.getData(dataContext))
+                    .map(IdeView::getDirectories)
+                    .filter(dirs -> !ArrayUtils.isEmpty(dirs));
+
+        return optionalProjectFileIndex
+            .flatMap(projectFileIndex -> optionalDirs.filter(dirs -> sourcePackageClassifier.containsJava(projectFileIndex, dirs)))
+            .isPresent();
+    }
 }
 

--- a/src/main/java/com/kenshoo/pl/intellij/controller/PlEntityWizardAction.java
+++ b/src/main/java/com/kenshoo/pl/intellij/controller/PlEntityWizardAction.java
@@ -1,12 +1,10 @@
 package com.kenshoo.pl.intellij.controller;
 
 import com.intellij.ide.IdeView;
-import com.intellij.openapi.actionSystem.*;
-import com.intellij.openapi.roots.ProjectFileIndex;
-import com.intellij.openapi.roots.ProjectRootManager;
-import com.intellij.psi.PsiDirectory;
+import com.intellij.openapi.actionSystem.AnAction;
+import com.intellij.openapi.actionSystem.AnActionEvent;
+import com.intellij.openapi.actionSystem.LangDataKeys;
 import com.kenshoo.pl.intellij.view.NewEntityFormWrapper;
-import org.apache.commons.lang.ArrayUtils;
 import org.jetbrains.annotations.NotNull;
 
 import java.util.Optional;
@@ -25,7 +23,7 @@ public class PlEntityWizardAction extends AnAction {
 
     @Override
     public void update(@NotNull AnActionEvent e) {
-        boolean available = isAvailable(e.getDataContext());
+        boolean available = sourcePackageClassifier.isJava(e.getDataContext());
         e.getPresentation().setEnabledAndVisible(available);
     }
 
@@ -35,22 +33,6 @@ public class PlEntityWizardAction extends AnAction {
                 .map(IdeView::getOrChooseDirectory)
                 .map(NewEntityFormWrapper::new)
                 .ifPresent(NewEntityFormWrapper::show);
-    }
-
-    private boolean isAvailable(DataContext dataContext) {
-        final Optional<ProjectFileIndex> optionalProjectFileIndex =
-            Optional.ofNullable(CommonDataKeys.PROJECT.getData(dataContext))
-                    .map(ProjectRootManager::getInstance)
-                    .map(ProjectRootManager::getFileIndex);
-
-        final Optional<PsiDirectory[]> optionalDirs =
-            Optional.ofNullable(LangDataKeys.IDE_VIEW.getData(dataContext))
-                    .map(IdeView::getDirectories)
-                    .filter(dirs -> !ArrayUtils.isEmpty(dirs));
-
-        return optionalProjectFileIndex
-            .flatMap(projectFileIndex -> optionalDirs.filter(dirs -> sourcePackageClassifier.containsJava(projectFileIndex, dirs)))
-            .isPresent();
     }
 }
 

--- a/src/main/java/com/kenshoo/pl/intellij/controller/SourcePackageClassifier.java
+++ b/src/main/java/com/kenshoo/pl/intellij/controller/SourcePackageClassifier.java
@@ -1,0 +1,21 @@
+package com.kenshoo.pl.intellij.controller;
+
+import com.intellij.ide.actions.JavaCreateTemplateInPackageAction;
+import com.intellij.openapi.roots.ProjectFileIndex;
+import com.intellij.psi.PsiDirectory;
+import org.jetbrains.jps.model.java.JavaModuleSourceRootTypes;
+
+import java.util.Arrays;
+
+class SourcePackageClassifier {
+
+    boolean containsJava(final ProjectFileIndex projectFileIndex, final PsiDirectory[] dirs) {
+        return Arrays.stream(dirs)
+                     .filter(dir -> projectFileIndex.isUnderSourceRootOfType(dir.getVirtualFile(), JavaModuleSourceRootTypes.SOURCES))
+                     .anyMatch(this::isJavaPackage);
+    }
+
+    boolean isJavaPackage(final PsiDirectory dir) {
+        return JavaCreateTemplateInPackageAction.doCheckPackageExists(dir);
+    }
+}

--- a/src/main/java/com/kenshoo/pl/intellij/controller/SourcePackageClassifier.java
+++ b/src/main/java/com/kenshoo/pl/intellij/controller/SourcePackageClassifier.java
@@ -1,20 +1,49 @@
 package com.kenshoo.pl.intellij.controller;
 
+import com.intellij.ide.IdeView;
 import com.intellij.ide.actions.JavaCreateTemplateInPackageAction;
+import com.intellij.openapi.actionSystem.CommonDataKeys;
+import com.intellij.openapi.actionSystem.DataContext;
+import com.intellij.openapi.actionSystem.LangDataKeys;
 import com.intellij.openapi.roots.ProjectFileIndex;
+import com.intellij.openapi.roots.ProjectRootManager;
 import com.intellij.psi.PsiDirectory;
+import org.apache.commons.lang.ArrayUtils;
 import org.jetbrains.jps.model.java.JavaModuleSourceRootTypes;
 
 import java.util.Arrays;
+import java.util.Optional;
 
 class SourcePackageClassifier {
 
-    boolean containsJava(final ProjectFileIndex projectFileIndex, final PsiDirectory[] dirs) {
+    boolean isJava(final DataContext dataContext) {
+        final Optional<ProjectFileIndex> optionalProjectFileIndex = extractProjectFileIndex(dataContext);
+        final Optional<PsiDirectory[]> optionalDirs = extractDirs(dataContext);
+
+        return optionalProjectFileIndex
+            .flatMap(projectFileIndex -> optionalDirs.filter(dirs -> containsJava(projectFileIndex, dirs)))
+            .isPresent();
+    }
+
+    private Optional<PsiDirectory[]> extractDirs(final DataContext dataContext) {
+        return Optional.ofNullable(LangDataKeys.IDE_VIEW.getData(dataContext))
+                       .map(IdeView::getDirectories)
+                       .filter(dirs -> !ArrayUtils.isEmpty(dirs));
+    }
+
+    private Optional<ProjectFileIndex> extractProjectFileIndex(final DataContext dataContext) {
+        return Optional.ofNullable(CommonDataKeys.PROJECT.getData(dataContext))
+                       .map(ProjectRootManager::getInstance)
+                       .map(ProjectRootManager::getFileIndex);
+    }
+
+    private boolean containsJava(final ProjectFileIndex projectFileIndex, final PsiDirectory[] dirs) {
         return Arrays.stream(dirs)
                      .filter(dir -> projectFileIndex.isUnderSourceRootOfType(dir.getVirtualFile(), JavaModuleSourceRootTypes.SOURCES))
                      .anyMatch(this::isJavaPackage);
     }
 
+    // visible for testing
     boolean isJavaPackage(final PsiDirectory dir) {
         return JavaCreateTemplateInPackageAction.doCheckPackageExists(dir);
     }

--- a/src/main/java/com/kenshoo/pl/intellij/view/NewEntityFormWrapper.java
+++ b/src/main/java/com/kenshoo/pl/intellij/view/NewEntityFormWrapper.java
@@ -1,7 +1,7 @@
 package com.kenshoo.pl.intellij.view;
 
 import com.intellij.openapi.ui.DialogWrapper;
-import com.intellij.psi.impl.file.PsiJavaDirectoryImpl;
+import com.intellij.psi.PsiDirectory;
 import com.kenshoo.pl.intellij.controller.NewEntityController;
 import com.kenshoo.pl.intellij.model.EntityInput;
 import com.kenshoo.pl.intellij.model.PLInputValidator;
@@ -19,11 +19,11 @@ public class NewEntityFormWrapper extends DialogWrapper {
 
     private final PLInputValidator validator = PLInputValidator.INSTANCE;
 
-    private final PsiJavaDirectoryImpl directory;
+    private final PsiDirectory directory;
     private final NewEntityForm form;
     private final NewEntityController controller;
 
-    public NewEntityFormWrapper(@Nullable PsiJavaDirectoryImpl directory) {
+    public NewEntityFormWrapper(@Nullable PsiDirectory directory) {
         super(true);
         this.controller = NewEntityController.INSTANCE;
         this.directory = directory;

--- a/src/test/java/com/kenshoo/pl/intellij/controller/PlEntityWizardActionTest.java
+++ b/src/test/java/com/kenshoo/pl/intellij/controller/PlEntityWizardActionTest.java
@@ -1,0 +1,145 @@
+package com.kenshoo.pl.intellij.controller;
+
+import com.intellij.ide.IdeView;
+import com.intellij.openapi.actionSystem.*;
+import com.intellij.openapi.project.Project;
+import com.intellij.openapi.roots.ProjectFileIndex;
+import com.intellij.openapi.roots.ProjectRootManager;
+import com.intellij.psi.PsiDirectory;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+import static org.mockito.AdditionalMatchers.aryEq;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.when;
+
+@RunWith(MockitoJUnitRunner.class)
+public class PlEntityWizardActionTest {
+
+    @Mock
+    private AnActionEvent event;
+
+    @Mock
+    private DataContext dataContext;
+
+    @Mock
+    private Project project;
+
+    @Mock
+    private ProjectRootManager projectRootManager;
+
+    @Mock
+    private ProjectFileIndex projectFileIndex;
+
+    @Mock
+    private SourcePackageClassifier sourcePackageClassifier;
+
+    @Mock
+    private IdeView ideView;
+
+    @Mock
+    private PsiDirectory dir1;
+
+    @Mock
+    private PsiDirectory dir2;
+
+    private final PsiDirectory[] dirs = new PsiDirectory[]{dir1, dir2};
+
+    @InjectMocks
+    private PlEntityWizardAction action;
+
+    @Test
+    public void updateWhenProjectAndViewDirsExistAndDirsIncludeJavaPackageShouldBeEnabledAndVisible() {
+        final Presentation presentation = new Presentation();
+
+        when(event.getDataContext()).thenReturn(dataContext);
+        when(CommonDataKeys.PROJECT.getData(dataContext)).thenReturn(project);
+        when(project.getComponent(ProjectRootManager.class)).thenReturn(projectRootManager);
+        when(projectRootManager.getFileIndex()).thenReturn(projectFileIndex);
+        when(LangDataKeys.IDE_VIEW.getData(dataContext)).thenReturn(ideView);
+        when(ideView.getDirectories()).thenReturn(dirs);
+        when(sourcePackageClassifier.containsJava(eq(projectFileIndex), aryEq(dirs))).thenReturn(true);
+        when(event.getPresentation()).thenReturn(presentation);
+
+        action.update(event);
+
+        assertThat(presentation.isEnabledAndVisible(), is(true));
+    }
+
+    @Test
+    public void updateWhenProjectAndViewDirsExistAndDirsAreEmptyShouldBeDisabledAndHidden() {
+        final Presentation presentation = new Presentation();
+        presentation.setEnabledAndVisible(true);
+
+        when(event.getDataContext()).thenReturn(dataContext);
+        when(CommonDataKeys.PROJECT.getData(dataContext)).thenReturn(project);
+        when(project.getComponent(ProjectRootManager.class)).thenReturn(projectRootManager);
+        when(projectRootManager.getFileIndex()).thenReturn(projectFileIndex);
+        when(LangDataKeys.IDE_VIEW.getData(dataContext)).thenReturn(ideView);
+        when(ideView.getDirectories()).thenReturn(new PsiDirectory[]{});
+        when(event.getPresentation()).thenReturn(presentation);
+
+        action.update(event);
+
+        assertThat(presentation.isEnabled(), is(false));
+        assertThat(presentation.isVisible(), is(false));
+    }
+
+    @Test
+    public void updateWhenProjectAndViewDirsExistAndDirsDoNotIncludeJavaPackageShouldBeDisabledAndHidden() {
+        final Presentation presentation = new Presentation();
+        presentation.setEnabledAndVisible(true);
+
+        when(event.getDataContext()).thenReturn(dataContext);
+        when(CommonDataKeys.PROJECT.getData(dataContext)).thenReturn(project);
+        when(project.getComponent(ProjectRootManager.class)).thenReturn(projectRootManager);
+        when(projectRootManager.getFileIndex()).thenReturn(projectFileIndex);
+        when(LangDataKeys.IDE_VIEW.getData(dataContext)).thenReturn(ideView);
+        when(ideView.getDirectories()).thenReturn(dirs);
+        when(sourcePackageClassifier.containsJava(eq(projectFileIndex), aryEq(dirs))).thenReturn(false);
+        when(event.getPresentation()).thenReturn(presentation);
+
+        action.update(event);
+
+        assertThat(presentation.isEnabled(), is(false));
+        assertThat(presentation.isVisible(), is(false));
+    }
+
+    @Test
+    public void updateWhenProjectExistsButViewDoesntShouldBeDisabledAndEmpty() {
+        final Presentation presentation = new Presentation();
+        presentation.setEnabledAndVisible(true);
+
+        when(event.getDataContext()).thenReturn(dataContext);
+        when(CommonDataKeys.PROJECT.getData(dataContext)).thenReturn(project);
+        when(project.getComponent(ProjectRootManager.class)).thenReturn(projectRootManager);
+        when(projectRootManager.getFileIndex()).thenReturn(projectFileIndex);
+        when(LangDataKeys.IDE_VIEW.getData(dataContext)).thenReturn(null);
+        when(event.getPresentation()).thenReturn(presentation);
+
+        action.update(event);
+
+        assertThat(presentation.isEnabled(), is(false));
+        assertThat(presentation.isVisible(), is(false));
+    }
+
+    @Test
+    public void updateWhenProjectDoesntExistShouldBeDisabledAndEmpty() {
+        final Presentation presentation = new Presentation();
+        presentation.setEnabledAndVisible(true);
+
+        when(event.getDataContext()).thenReturn(dataContext);
+        when(CommonDataKeys.PROJECT.getData(dataContext)).thenReturn(null);
+        when(event.getPresentation()).thenReturn(presentation);
+
+        action.update(event);
+
+        assertThat(presentation.isEnabled(), is(false));
+        assertThat(presentation.isVisible(), is(false));
+    }
+}

--- a/src/test/java/com/kenshoo/pl/intellij/controller/PlEntityWizardActionTest.java
+++ b/src/test/java/com/kenshoo/pl/intellij/controller/PlEntityWizardActionTest.java
@@ -1,11 +1,8 @@
 package com.kenshoo.pl.intellij.controller;
 
-import com.intellij.ide.IdeView;
-import com.intellij.openapi.actionSystem.*;
-import com.intellij.openapi.project.Project;
-import com.intellij.openapi.roots.ProjectFileIndex;
-import com.intellij.openapi.roots.ProjectRootManager;
-import com.intellij.psi.PsiDirectory;
+import com.intellij.openapi.actionSystem.AnActionEvent;
+import com.intellij.openapi.actionSystem.DataContext;
+import com.intellij.openapi.actionSystem.Presentation;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.InjectMocks;
@@ -14,8 +11,6 @@ import org.mockito.junit.MockitoJUnitRunner;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.assertThat;
-import static org.mockito.AdditionalMatchers.aryEq;
-import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.when;
 
 @RunWith(MockitoJUnitRunner.class)
@@ -28,42 +23,17 @@ public class PlEntityWizardActionTest {
     private DataContext dataContext;
 
     @Mock
-    private Project project;
-
-    @Mock
-    private ProjectRootManager projectRootManager;
-
-    @Mock
-    private ProjectFileIndex projectFileIndex;
-
-    @Mock
     private SourcePackageClassifier sourcePackageClassifier;
-
-    @Mock
-    private IdeView ideView;
-
-    @Mock
-    private PsiDirectory dir1;
-
-    @Mock
-    private PsiDirectory dir2;
-
-    private final PsiDirectory[] dirs = new PsiDirectory[]{dir1, dir2};
 
     @InjectMocks
     private PlEntityWizardAction action;
 
     @Test
-    public void updateWhenProjectAndViewDirsExistAndDirsIncludeJavaPackageShouldBeEnabledAndVisible() {
+    public void updateWhenIsJavaSourcePackageShouldBeEnabledAndVisible() {
         final Presentation presentation = new Presentation();
 
         when(event.getDataContext()).thenReturn(dataContext);
-        when(CommonDataKeys.PROJECT.getData(dataContext)).thenReturn(project);
-        when(project.getComponent(ProjectRootManager.class)).thenReturn(projectRootManager);
-        when(projectRootManager.getFileIndex()).thenReturn(projectFileIndex);
-        when(LangDataKeys.IDE_VIEW.getData(dataContext)).thenReturn(ideView);
-        when(ideView.getDirectories()).thenReturn(dirs);
-        when(sourcePackageClassifier.containsJava(eq(projectFileIndex), aryEq(dirs))).thenReturn(true);
+        when(sourcePackageClassifier.isJava(dataContext)).thenReturn(true);
         when(event.getPresentation()).thenReturn(presentation);
 
         action.update(event);
@@ -72,74 +42,17 @@ public class PlEntityWizardActionTest {
     }
 
     @Test
-    public void updateWhenProjectAndViewDirsExistAndDirsAreEmptyShouldBeDisabledAndHidden() {
+    public void updateWhenNotJavaSourcePackageShouldBeDisabledAndInvisible() {
         final Presentation presentation = new Presentation();
         presentation.setEnabledAndVisible(true);
 
         when(event.getDataContext()).thenReturn(dataContext);
-        when(CommonDataKeys.PROJECT.getData(dataContext)).thenReturn(project);
-        when(project.getComponent(ProjectRootManager.class)).thenReturn(projectRootManager);
-        when(projectRootManager.getFileIndex()).thenReturn(projectFileIndex);
-        when(LangDataKeys.IDE_VIEW.getData(dataContext)).thenReturn(ideView);
-        when(ideView.getDirectories()).thenReturn(new PsiDirectory[]{});
+        when(sourcePackageClassifier.isJava(dataContext)).thenReturn(false);
         when(event.getPresentation()).thenReturn(presentation);
 
         action.update(event);
 
-        assertThat(presentation.isEnabled(), is(false));
-        assertThat(presentation.isVisible(), is(false));
-    }
-
-    @Test
-    public void updateWhenProjectAndViewDirsExistAndDirsDoNotIncludeJavaPackageShouldBeDisabledAndHidden() {
-        final Presentation presentation = new Presentation();
-        presentation.setEnabledAndVisible(true);
-
-        when(event.getDataContext()).thenReturn(dataContext);
-        when(CommonDataKeys.PROJECT.getData(dataContext)).thenReturn(project);
-        when(project.getComponent(ProjectRootManager.class)).thenReturn(projectRootManager);
-        when(projectRootManager.getFileIndex()).thenReturn(projectFileIndex);
-        when(LangDataKeys.IDE_VIEW.getData(dataContext)).thenReturn(ideView);
-        when(ideView.getDirectories()).thenReturn(dirs);
-        when(sourcePackageClassifier.containsJava(eq(projectFileIndex), aryEq(dirs))).thenReturn(false);
-        when(event.getPresentation()).thenReturn(presentation);
-
-        action.update(event);
-
-        assertThat(presentation.isEnabled(), is(false));
-        assertThat(presentation.isVisible(), is(false));
-    }
-
-    @Test
-    public void updateWhenProjectExistsButViewDoesntShouldBeDisabledAndEmpty() {
-        final Presentation presentation = new Presentation();
-        presentation.setEnabledAndVisible(true);
-
-        when(event.getDataContext()).thenReturn(dataContext);
-        when(CommonDataKeys.PROJECT.getData(dataContext)).thenReturn(project);
-        when(project.getComponent(ProjectRootManager.class)).thenReturn(projectRootManager);
-        when(projectRootManager.getFileIndex()).thenReturn(projectFileIndex);
-        when(LangDataKeys.IDE_VIEW.getData(dataContext)).thenReturn(null);
-        when(event.getPresentation()).thenReturn(presentation);
-
-        action.update(event);
-
-        assertThat(presentation.isEnabled(), is(false));
-        assertThat(presentation.isVisible(), is(false));
-    }
-
-    @Test
-    public void updateWhenProjectDoesntExistShouldBeDisabledAndEmpty() {
-        final Presentation presentation = new Presentation();
-        presentation.setEnabledAndVisible(true);
-
-        when(event.getDataContext()).thenReturn(dataContext);
-        when(CommonDataKeys.PROJECT.getData(dataContext)).thenReturn(null);
-        when(event.getPresentation()).thenReturn(presentation);
-
-        action.update(event);
-
-        assertThat(presentation.isEnabled(), is(false));
-        assertThat(presentation.isVisible(), is(false));
+        assertThat("Should be disabled: ", presentation.isEnabled(), is(false));
+        assertThat("Should be invisible: ", presentation.isVisible(), is(false));
     }
 }

--- a/src/test/java/com/kenshoo/pl/intellij/controller/SourcePackageClassifierTest.java
+++ b/src/test/java/com/kenshoo/pl/intellij/controller/SourcePackageClassifierTest.java
@@ -1,13 +1,22 @@
 package com.kenshoo.pl.intellij.controller;
 
+import com.intellij.ide.IdeView;
+import com.intellij.openapi.actionSystem.CommonDataKeys;
+import com.intellij.openapi.actionSystem.DataContext;
+import com.intellij.openapi.actionSystem.LangDataKeys;
+import com.intellij.openapi.project.Project;
 import com.intellij.openapi.roots.ProjectFileIndex;
+import com.intellij.openapi.roots.ProjectRootManager;
 import com.intellij.openapi.vfs.VirtualFile;
 import com.intellij.psi.PsiDirectory;
 import org.jetbrains.jps.model.java.JavaModuleSourceRootTypes;
+import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
+
+import java.util.function.Predicate;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.assertThat;
@@ -17,7 +26,19 @@ import static org.mockito.Mockito.when;
 public class SourcePackageClassifierTest {
 
     @Mock
+    private DataContext dataContext;
+
+    @Mock
+    private Project project;
+
+    @Mock
+    private ProjectRootManager projectRootManager;
+
+    @Mock
     private ProjectFileIndex projectFileIndex;
+
+    @Mock
+    private IdeView ideView;
 
     @Mock
     private PsiDirectory dir1;
@@ -31,81 +52,123 @@ public class SourcePackageClassifierTest {
     @Mock
     private VirtualFile virtualFile2;
 
-    @Test
-    public void containsJavaWhenFirstDirMatchesConditionsShouldReturnTrue() {
-        when(dir1.getVirtualFile()).thenReturn(virtualFile1);
-        when(projectFileIndex.isUnderSourceRootOfType(virtualFile1, JavaModuleSourceRootTypes.SOURCES)).thenReturn(true);
+    private PsiDirectory[] dirs;
 
-        final SourcePackageClassifier sourcePackageClassifier = new SourcePackageClassifier() {
-            boolean isJavaPackage(final PsiDirectory dir) {
-                return true;
-            }
-        };
-
-        assertThat(sourcePackageClassifier.containsJava(projectFileIndex, new PsiDirectory[]{dir1, dir2}), is(true));
+    @Before
+    public void setUp() {
+        dirs = new PsiDirectory[]{dir1, dir2};
     }
 
     @Test
-    public void containsJavaWhenFirstDirIsNotJavaSourceAndSecondDirMatchesConditionsShouldReturnTrue() {
+    public void isJavaWhenFirstDirMatchesConditionsShouldReturnTrue() {
+        mockExtractDirs();
+        when(dir1.getVirtualFile()).thenReturn(virtualFile1);
+        when(projectFileIndex.isUnderSourceRootOfType(virtualFile1, JavaModuleSourceRootTypes.SOURCES)).thenReturn(true);
+
+        final SourcePackageClassifier classifier = createClassifier(__ -> true);
+
+        assertThat(classifier.isJava(dataContext), is(true));
+    }
+
+    @Test
+    public void isJavaWhenFirstDirIsNotJavaSourceAndSecondDirMatchesConditionsShouldReturnTrue() {
+        mockExtractDirs();
         when(dir1.getVirtualFile()).thenReturn(virtualFile1);
         when(dir2.getVirtualFile()).thenReturn(virtualFile2);
         when(projectFileIndex.isUnderSourceRootOfType(virtualFile1, JavaModuleSourceRootTypes.SOURCES)).thenReturn(false);
         when(projectFileIndex.isUnderSourceRootOfType(virtualFile2, JavaModuleSourceRootTypes.SOURCES)).thenReturn(true);
 
-        final SourcePackageClassifier sourcePackageClassifier = new SourcePackageClassifier() {
-            boolean isJavaPackage(final PsiDirectory dir) {
-                return true;
-            }
-        };
+        final SourcePackageClassifier classifier = createClassifier(__ -> true);
 
-        assertThat(sourcePackageClassifier.containsJava(projectFileIndex, new PsiDirectory[]{dir1, dir2}), is(true));
+        assertThat(classifier.isJava(dataContext), is(true));
     }
 
     @Test
-    public void containsJavaWhenFirstDirIsJavaSourceButNotPackageAndSecondDirMatchesConditionsShouldReturnTrue() {
+    public void isJavaWhenFirstDirIsJavaSourceButNotPackageAndSecondDirMatchesConditionsShouldReturnTrue() {
+        mockExtractDirs();
         when(dir1.getVirtualFile()).thenReturn(virtualFile1);
         when(dir2.getVirtualFile()).thenReturn(virtualFile2);
         when(projectFileIndex.isUnderSourceRootOfType(virtualFile1, JavaModuleSourceRootTypes.SOURCES)).thenReturn(true);
         when(projectFileIndex.isUnderSourceRootOfType(virtualFile2, JavaModuleSourceRootTypes.SOURCES)).thenReturn(true);
 
-        final SourcePackageClassifier sourcePackageClassifier = new SourcePackageClassifier() {
-            boolean isJavaPackage(final PsiDirectory dir) {
-                return dir == dir2;
-            }
-        };
+        final SourcePackageClassifier classifier = createClassifier(dir2::equals);
 
-        assertThat(sourcePackageClassifier.containsJava(projectFileIndex, new PsiDirectory[]{dir1, dir2}), is(true));
+        assertThat(classifier.isJava(dataContext), is(true));
     }
 
     @Test
-    public void containsJavaWhenBothAreJavaSourcesButNotPackagesShouldReturnFalse() {
+    public void isJavaWhenBothDirsAreJavaSourcesButNotPackagesShouldReturnFalse() {
+        mockExtractDirs();
         when(dir1.getVirtualFile()).thenReturn(virtualFile1);
         when(dir2.getVirtualFile()).thenReturn(virtualFile2);
         when(projectFileIndex.isUnderSourceRootOfType(virtualFile1, JavaModuleSourceRootTypes.SOURCES)).thenReturn(true);
         when(projectFileIndex.isUnderSourceRootOfType(virtualFile2, JavaModuleSourceRootTypes.SOURCES)).thenReturn(true);
 
-        final SourcePackageClassifier sourcePackageClassifier = new SourcePackageClassifier() {
-            boolean isJavaPackage(final PsiDirectory dir) {
-                return false;
-            }
-        };
+        final SourcePackageClassifier classifier = createClassifier(__ -> false);
 
-        assertThat(sourcePackageClassifier.containsJava(projectFileIndex, new PsiDirectory[]{dir1, dir2}), is(false));
+        assertThat(classifier.isJava(dataContext), is(false));
     }
 
     @Test
-    public void containsJavaWhenNeitherAreJavaSourcesShouldReturnFalse() {
+    public void isJavaWhenNeitherDirIsJavaSourceShouldReturnFalse() {
+        mockExtractDirs();
         when(dir1.getVirtualFile()).thenReturn(virtualFile1);
         when(dir2.getVirtualFile()).thenReturn(virtualFile2);
         when(projectFileIndex.isUnderSourceRootOfType(virtualFile1, JavaModuleSourceRootTypes.SOURCES)).thenReturn(false);
         when(projectFileIndex.isUnderSourceRootOfType(virtualFile2, JavaModuleSourceRootTypes.SOURCES)).thenReturn(false);
 
-        final SourcePackageClassifier sourcePackageClassifier = new SourcePackageClassifier() {
+        final SourcePackageClassifier classifier = createClassifier(__ -> true);
+
+        assertThat(classifier.isJava(dataContext), is(false));
+    }
+
+    @Test
+    public void isJavaWhenViewExistButDirsAreEmptyShouldReturnFalse() {
+        when(dataContext.getData(CommonDataKeys.PROJECT.getName())).thenReturn(project);
+        when(project.getComponent(ProjectRootManager.class)).thenReturn(projectRootManager);
+        when(projectRootManager.getFileIndex()).thenReturn(projectFileIndex);
+        when(dataContext.getData(LangDataKeys.IDE_VIEW.getName())).thenReturn(ideView);
+        when(ideView.getDirectories()).thenReturn(new PsiDirectory[]{});
+
+        final SourcePackageClassifier classifier = createClassifier(__ -> true);
+
+        assertThat(classifier.isJava(dataContext), is(false));
+    }
+
+    @Test
+    public void isJavaWhenProjectExistsButViewDoesntShouldReturnFalse() {
+        when(dataContext.getData(CommonDataKeys.PROJECT.getName())).thenReturn(project);
+        when(project.getComponent(ProjectRootManager.class)).thenReturn(projectRootManager);
+        when(projectRootManager.getFileIndex()).thenReturn(projectFileIndex);
+        when(dataContext.getData(LangDataKeys.IDE_VIEW.getName())).thenReturn(null);
+
+        final SourcePackageClassifier classifier = createClassifier(__ -> true);
+
+        assertThat(classifier.isJava(dataContext), is(false));
+    }
+
+    @Test
+    public void isJavaWhenProjectDoesntExistShouldReturnFalse() {
+        when(dataContext.getData(CommonDataKeys.PROJECT.getName())).thenReturn(null);
+
+        final SourcePackageClassifier classifier = createClassifier(__ -> true);
+
+        assertThat(classifier.isJava(dataContext), is(false));
+    }
+
+    private void mockExtractDirs() {
+        when(dataContext.getData(CommonDataKeys.PROJECT.getName())).thenReturn(project);
+        when(project.getComponent(ProjectRootManager.class)).thenReturn(projectRootManager);
+        when(projectRootManager.getFileIndex()).thenReturn(projectFileIndex);
+        when(dataContext.getData(LangDataKeys.IDE_VIEW.getName())).thenReturn(ideView);
+        when(ideView.getDirectories()).thenReturn(dirs);
+    }
+
+    private SourcePackageClassifier createClassifier(final Predicate<PsiDirectory> javaPackagePredicate) {
+        return new SourcePackageClassifier() {
             boolean isJavaPackage(final PsiDirectory dir) {
-                return true;
+                return javaPackagePredicate.test(dir);
             }
         };
-
-        assertThat(sourcePackageClassifier.containsJava(projectFileIndex, new PsiDirectory[]{dir1, dir2}), is(false));
     }
 }

--- a/src/test/java/com/kenshoo/pl/intellij/controller/SourcePackageClassifierTest.java
+++ b/src/test/java/com/kenshoo/pl/intellij/controller/SourcePackageClassifierTest.java
@@ -1,0 +1,111 @@
+package com.kenshoo.pl.intellij.controller;
+
+import com.intellij.openapi.roots.ProjectFileIndex;
+import com.intellij.openapi.vfs.VirtualFile;
+import com.intellij.psi.PsiDirectory;
+import org.jetbrains.jps.model.java.JavaModuleSourceRootTypes;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+import static org.mockito.Mockito.when;
+
+@RunWith(MockitoJUnitRunner.class)
+public class SourcePackageClassifierTest {
+
+    @Mock
+    private ProjectFileIndex projectFileIndex;
+
+    @Mock
+    private PsiDirectory dir1;
+
+    @Mock
+    private PsiDirectory dir2;
+
+    @Mock
+    private VirtualFile virtualFile1;
+
+    @Mock
+    private VirtualFile virtualFile2;
+
+    @Test
+    public void containsJavaWhenFirstDirMatchesConditionsShouldReturnTrue() {
+        when(dir1.getVirtualFile()).thenReturn(virtualFile1);
+        when(projectFileIndex.isUnderSourceRootOfType(virtualFile1, JavaModuleSourceRootTypes.SOURCES)).thenReturn(true);
+
+        final SourcePackageClassifier sourcePackageClassifier = new SourcePackageClassifier() {
+            boolean isJavaPackage(final PsiDirectory dir) {
+                return true;
+            }
+        };
+
+        assertThat(sourcePackageClassifier.containsJava(projectFileIndex, new PsiDirectory[]{dir1, dir2}), is(true));
+    }
+
+    @Test
+    public void containsJavaWhenFirstDirIsNotJavaSourceAndSecondDirMatchesConditionsShouldReturnTrue() {
+        when(dir1.getVirtualFile()).thenReturn(virtualFile1);
+        when(dir2.getVirtualFile()).thenReturn(virtualFile2);
+        when(projectFileIndex.isUnderSourceRootOfType(virtualFile1, JavaModuleSourceRootTypes.SOURCES)).thenReturn(false);
+        when(projectFileIndex.isUnderSourceRootOfType(virtualFile2, JavaModuleSourceRootTypes.SOURCES)).thenReturn(true);
+
+        final SourcePackageClassifier sourcePackageClassifier = new SourcePackageClassifier() {
+            boolean isJavaPackage(final PsiDirectory dir) {
+                return true;
+            }
+        };
+
+        assertThat(sourcePackageClassifier.containsJava(projectFileIndex, new PsiDirectory[]{dir1, dir2}), is(true));
+    }
+
+    @Test
+    public void containsJavaWhenFirstDirIsJavaSourceButNotPackageAndSecondDirMatchesConditionsShouldReturnTrue() {
+        when(dir1.getVirtualFile()).thenReturn(virtualFile1);
+        when(dir2.getVirtualFile()).thenReturn(virtualFile2);
+        when(projectFileIndex.isUnderSourceRootOfType(virtualFile1, JavaModuleSourceRootTypes.SOURCES)).thenReturn(true);
+        when(projectFileIndex.isUnderSourceRootOfType(virtualFile2, JavaModuleSourceRootTypes.SOURCES)).thenReturn(true);
+
+        final SourcePackageClassifier sourcePackageClassifier = new SourcePackageClassifier() {
+            boolean isJavaPackage(final PsiDirectory dir) {
+                return dir == dir2;
+            }
+        };
+
+        assertThat(sourcePackageClassifier.containsJava(projectFileIndex, new PsiDirectory[]{dir1, dir2}), is(true));
+    }
+
+    @Test
+    public void containsJavaWhenBothAreJavaSourcesButNotPackagesShouldReturnFalse() {
+        when(dir1.getVirtualFile()).thenReturn(virtualFile1);
+        when(dir2.getVirtualFile()).thenReturn(virtualFile2);
+        when(projectFileIndex.isUnderSourceRootOfType(virtualFile1, JavaModuleSourceRootTypes.SOURCES)).thenReturn(true);
+        when(projectFileIndex.isUnderSourceRootOfType(virtualFile2, JavaModuleSourceRootTypes.SOURCES)).thenReturn(true);
+
+        final SourcePackageClassifier sourcePackageClassifier = new SourcePackageClassifier() {
+            boolean isJavaPackage(final PsiDirectory dir) {
+                return false;
+            }
+        };
+
+        assertThat(sourcePackageClassifier.containsJava(projectFileIndex, new PsiDirectory[]{dir1, dir2}), is(false));
+    }
+
+    @Test
+    public void containsJavaWhenNeitherAreJavaSourcesShouldReturnFalse() {
+        when(dir1.getVirtualFile()).thenReturn(virtualFile1);
+        when(dir2.getVirtualFile()).thenReturn(virtualFile2);
+        when(projectFileIndex.isUnderSourceRootOfType(virtualFile1, JavaModuleSourceRootTypes.SOURCES)).thenReturn(false);
+        when(projectFileIndex.isUnderSourceRootOfType(virtualFile2, JavaModuleSourceRootTypes.SOURCES)).thenReturn(false);
+
+        final SourcePackageClassifier sourcePackageClassifier = new SourcePackageClassifier() {
+            boolean isJavaPackage(final PsiDirectory dir) {
+                return true;
+            }
+        };
+
+        assertThat(sourcePackageClassifier.containsJava(projectFileIndex, new PsiDirectory[]{dir1, dir2}), is(false));
+    }
+}


### PR DESCRIPTION
Fixing the visibility so that it shows only when you click on a Java package which is under a Java source root (`src/main/java` `src/test/java`, `src/integration-test/java` etc.).
This is also a preparation for adding Scala support.

The implementation is based on code from `JavaCreateTemplateInPackageAction` and its parents - because that's a similar action that is enabled in the same cases.
It didn't seem possible to extend it, but I was able to reuse one static method

