### PR TITLE
Add ability to distinguish Scala from Java when form is opened

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'java'
-    id 'org.jetbrains.intellij' version '0.4.26'
+    id 'org.jetbrains.intellij' version '0.7.2'
 }
 
 group 'com.kenshoo'
@@ -18,17 +18,15 @@ dependencies {
     testCompile group: 'junit', name: 'junit', version: '4.12'
     testCompile group: 'org.mockito', name: 'mockito-core', version: '2.28.2'
     testCompile group: 'org.hamcrest', name: 'hamcrest-library', version: '1.3'
-    testCompile group: 'com.kenshoo', name: 'persistence-layer', version: '0.1.55-jooq-3.10.4'
+    testCompile group: 'com.kenshoo', name: 'persistence-layer', version: '0.1.63-jooq-3.10.4'
 }
 
 intellij {
-    version '2019.1.1'
+    version '2020.1.4'
+    plugins = ['com.intellij.java', 'org.intellij.scala:2020.1.43']
 }
 
 patchPluginXml {
-
-    patchPluginXml {
-        sinceBuild '191'
-        untilBuild '253'
-    }
+    sinceBuild '201'
+    untilBuild '253'
 }

--- a/src/main/java/com/kenshoo/pl/intellij/classifier/ModuleClassifier.java
+++ b/src/main/java/com/kenshoo/pl/intellij/classifier/ModuleClassifier.java
@@ -1,0 +1,38 @@
+package com.kenshoo.pl.intellij.classifier;
+
+import com.intellij.openapi.actionSystem.DataContext;
+import com.intellij.openapi.actionSystem.LangDataKeys;
+import com.intellij.openapi.module.Module;
+import com.intellij.openapi.roots.OrderEnumerator;
+import com.intellij.openapi.roots.libraries.Library;
+import com.intellij.util.CommonProcessors.FindProcessor;
+import com.kenshoo.pl.intellij.model.Language;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.Optional;
+
+import static com.kenshoo.pl.intellij.model.Language.JAVA;
+import static com.kenshoo.pl.intellij.model.Language.SCALA;
+
+public class ModuleClassifier {
+
+    public Language determineLanguage(@NotNull final DataContext dataContext) {
+        final FindProcessor<? super Library> scalaFindProcessor = newScalaFindProcessor();
+
+        Optional.ofNullable(LangDataKeys.MODULE.getData(dataContext))
+                .map(OrderEnumerator::orderEntries)
+                .map(OrderEnumerator::librariesOnly)
+                .ifPresent(orderEnumerator -> orderEnumerator.forEachLibrary(scalaFindProcessor));
+
+        return Optional.ofNullable(scalaFindProcessor.getFoundValue())
+                       .map(__ -> SCALA)
+                       .orElse(JAVA);
+    }
+
+    // Visible for testing
+    FindProcessor<? super Library> newScalaFindProcessor() {
+        return new ScalaLibraryFindProcessor();
+    }
+}
+
+

--- a/src/main/java/com/kenshoo/pl/intellij/classifier/ScalaLibraryFindProcessor.java
+++ b/src/main/java/com/kenshoo/pl/intellij/classifier/ScalaLibraryFindProcessor.java
@@ -1,0 +1,15 @@
+package com.kenshoo.pl.intellij.classifier;
+
+import com.intellij.openapi.roots.impl.libraries.LibraryEx;
+import com.intellij.openapi.roots.libraries.Library;
+import com.intellij.util.CommonProcessors.FindProcessor;
+import org.jetbrains.plugins.scala.project.ScalaLibraryType$;
+
+class ScalaLibraryFindProcessor extends FindProcessor<Library> {
+
+    @Override
+    protected boolean accept(final Library library) {
+        return (library instanceof LibraryEx) &&
+            ScalaLibraryType$.MODULE$.apply().getKind().equals(((LibraryEx)library).getKind());
+    }
+}

--- a/src/main/java/com/kenshoo/pl/intellij/classifier/SourcePackageClassifier.java
+++ b/src/main/java/com/kenshoo/pl/intellij/classifier/SourcePackageClassifier.java
@@ -1,4 +1,4 @@
-package com.kenshoo.pl.intellij.controller;
+package com.kenshoo.pl.intellij.classifier;
 
 import com.intellij.ide.IdeView;
 import com.intellij.ide.actions.JavaCreateTemplateInPackageAction;
@@ -14,9 +14,9 @@ import org.jetbrains.jps.model.java.JavaModuleSourceRootTypes;
 import java.util.Arrays;
 import java.util.Optional;
 
-class SourcePackageClassifier {
+public class SourcePackageClassifier {
 
-    boolean isJava(final DataContext dataContext) {
+    public boolean isJava(final DataContext dataContext) {
         final Optional<ProjectFileIndex> optionalProjectFileIndex = extractProjectFileIndex(dataContext);
         final Optional<PsiDirectory[]> optionalDirs = extractDirs(dataContext);
 

--- a/src/main/java/com/kenshoo/pl/intellij/controller/PlEntityWizardAction.java
+++ b/src/main/java/com/kenshoo/pl/intellij/controller/PlEntityWizardAction.java
@@ -3,7 +3,12 @@ package com.kenshoo.pl.intellij.controller;
 import com.intellij.ide.IdeView;
 import com.intellij.openapi.actionSystem.AnAction;
 import com.intellij.openapi.actionSystem.AnActionEvent;
+import com.intellij.openapi.actionSystem.DataContext;
 import com.intellij.openapi.actionSystem.LangDataKeys;
+import com.intellij.psi.PsiDirectory;
+import com.kenshoo.pl.intellij.classifier.ModuleClassifier;
+import com.kenshoo.pl.intellij.classifier.SourcePackageClassifier;
+import com.kenshoo.pl.intellij.model.Language;
 import com.kenshoo.pl.intellij.view.NewEntityFormWrapper;
 import org.jetbrains.annotations.NotNull;
 
@@ -12,13 +17,17 @@ import java.util.Optional;
 public class PlEntityWizardAction extends AnAction {
 
     private final SourcePackageClassifier sourcePackageClassifier;
+    private final ModuleClassifier moduleClassifier;
 
     public PlEntityWizardAction() {
-        this(new SourcePackageClassifier());
+        this(new SourcePackageClassifier(),
+             new ModuleClassifier());
     }
 
-    PlEntityWizardAction(final SourcePackageClassifier sourcePackageClassifier) {
+    PlEntityWizardAction(final SourcePackageClassifier sourcePackageClassifier,
+                         final ModuleClassifier moduleClassifier) {
         this.sourcePackageClassifier = sourcePackageClassifier;
+        this.moduleClassifier = moduleClassifier;
     }
 
     @Override
@@ -29,10 +38,17 @@ public class PlEntityWizardAction extends AnAction {
 
     @Override
     public void actionPerformed(@NotNull AnActionEvent e) {
-        Optional.ofNullable(LangDataKeys.IDE_VIEW.getData(e.getDataContext()))
+        final DataContext dataContext = e.getDataContext();
+
+        Optional.ofNullable(LangDataKeys.IDE_VIEW.getData(dataContext))
                 .map(IdeView::getOrChooseDirectory)
-                .map(NewEntityFormWrapper::new)
+                .map(dir -> newEntityFormWrapper(dir, moduleClassifier.determineLanguage(dataContext)))
                 .ifPresent(NewEntityFormWrapper::show);
+    }
+
+    // Visible for testing
+    NewEntityFormWrapper newEntityFormWrapper(final PsiDirectory dir, final Language language) {
+        return new NewEntityFormWrapper(dir, language);
     }
 }
 

--- a/src/main/java/com/kenshoo/pl/intellij/model/Language.java
+++ b/src/main/java/com/kenshoo/pl/intellij/model/Language.java
@@ -1,0 +1,6 @@
+package com.kenshoo.pl.intellij.model;
+
+public enum Language {
+    JAVA,
+    SCALA
+}

--- a/src/main/java/com/kenshoo/pl/intellij/view/NewEntityFormWrapper.java
+++ b/src/main/java/com/kenshoo/pl/intellij/view/NewEntityFormWrapper.java
@@ -4,15 +4,18 @@ import com.intellij.openapi.ui.DialogWrapper;
 import com.intellij.psi.PsiDirectory;
 import com.kenshoo.pl.intellij.controller.NewEntityController;
 import com.kenshoo.pl.intellij.model.EntityInput;
+import com.kenshoo.pl.intellij.model.Language;
 import com.kenshoo.pl.intellij.model.PLInputValidator;
 import com.kenshoo.pl.intellij.model.ValidationError;
 import org.apache.commons.lang3.exception.ExceptionUtils;
+import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 import javax.swing.*;
 import java.util.Optional;
 
 import static com.intellij.openapi.ui.Messages.showMessageDialog;
+import static com.kenshoo.pl.intellij.model.Language.SCALA;
 
 
 public class NewEntityFormWrapper extends DialogWrapper {
@@ -22,14 +25,17 @@ public class NewEntityFormWrapper extends DialogWrapper {
     private final PsiDirectory directory;
     private final NewEntityForm form;
     private final NewEntityController controller;
+    private final Language language;
 
-    public NewEntityFormWrapper(@Nullable PsiDirectory directory) {
+    public NewEntityFormWrapper(@Nullable final PsiDirectory directory,
+                                @NotNull final Language language) {
         super(true);
         this.controller = NewEntityController.INSTANCE;
         this.directory = directory;
         this.form = new NewEntityForm();
         init();
-        setTitle("New PL Entity");
+        this.language = language;
+        setTitle("New PL Entity" + (language == SCALA ? " in Scala" : ""));
     }
 
     @Nullable

--- a/src/main/resources/META-INF/com.kenshoo.pl-intellij-plugin-scala.xml
+++ b/src/main/resources/META-INF/com.kenshoo.pl-intellij-plugin-scala.xml
@@ -1,0 +1,3 @@
+<idea-plugin>
+
+</idea-plugin>

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -31,5 +31,5 @@
         </action>
     </actions>
 
-    <depends>com.intellij.modules.java</depends>
+    <depends optional="true" config-file="com.kenshoo.pl-intellij-plugin-scala.xml">org.intellij.scala</depends>
 </idea-plugin>

--- a/src/test/java/com/kenshoo/pl/intellij/classifier/ModuleClassifierTest.java
+++ b/src/test/java/com/kenshoo/pl/intellij/classifier/ModuleClassifierTest.java
@@ -1,0 +1,89 @@
+package com.kenshoo.pl.intellij.classifier;
+
+import com.intellij.openapi.actionSystem.DataContext;
+import com.intellij.openapi.actionSystem.LangDataKeys;
+import com.intellij.openapi.module.Module;
+import com.intellij.openapi.roots.ModuleRootManager;
+import com.intellij.openapi.roots.OrderEnumerator;
+import com.intellij.openapi.roots.libraries.Library;
+import com.intellij.util.CommonProcessors.FindProcessor;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+
+import static com.kenshoo.pl.intellij.model.Language.JAVA;
+import static com.kenshoo.pl.intellij.model.Language.SCALA;
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@RunWith(MockitoJUnitRunner.class)
+public class ModuleClassifierTest {
+
+    @Mock
+    private DataContext dataContext;
+
+    @Mock
+    private Module module;
+
+    @Mock
+    private ModuleRootManager moduleRootManager;
+
+    @Mock
+    private OrderEnumerator orderEnumerator;
+
+    @Mock
+    private FindProcessor<? super Library> scalaLibraryFindProcessor;
+
+    @Mock
+    private Library scalaLibrary;
+
+    private ModuleClassifier moduleClassifier;
+
+    @Before
+    public void setUp() {
+        moduleClassifier = new ModuleClassifier() {
+
+            @Override
+            FindProcessor<? super Library> newScalaFindProcessor() {
+                return scalaLibraryFindProcessor;
+            }
+        };
+    }
+
+    @Test
+    public void determineLanguageWhenContainsScalaLibraryShouldReturnJava() {
+        when(dataContext.getData(LangDataKeys.MODULE.getName())).thenReturn(module);
+        when(module.getComponent(ModuleRootManager.class)).thenReturn(moduleRootManager);
+        when(moduleRootManager.orderEntries()).thenReturn(orderEnumerator);
+        when(orderEnumerator.librariesOnly()).thenReturn(orderEnumerator);
+        when(scalaLibraryFindProcessor.getFoundValue()).thenReturn(scalaLibrary);
+
+        assertThat(moduleClassifier.determineLanguage(dataContext), is(SCALA));
+
+        verify(orderEnumerator).forEachLibrary(scalaLibraryFindProcessor);
+    }
+
+    @Test
+    public void determineLanguageWhenDoesntContainScalaLibraryShouldReturnJava() {
+        when(dataContext.getData(LangDataKeys.MODULE.getName())).thenReturn(module);
+        when(module.getComponent(ModuleRootManager.class)).thenReturn(moduleRootManager);
+        when(moduleRootManager.orderEntries()).thenReturn(orderEnumerator);
+        when(orderEnumerator.librariesOnly()).thenReturn(orderEnumerator);
+        when(scalaLibraryFindProcessor.getFoundValue()).thenReturn(null);
+
+        assertThat(moduleClassifier.determineLanguage(dataContext), is(JAVA));
+
+        verify(orderEnumerator).forEachLibrary(scalaLibraryFindProcessor);
+    }
+
+    @Test
+    public void determineLanguageWhenModuleDoesntExistShouldReturnJava() {
+        when(dataContext.getData(LangDataKeys.MODULE.getName())).thenReturn(null);
+
+        assertThat(moduleClassifier.determineLanguage(dataContext), is(JAVA));
+    }
+}

--- a/src/test/java/com/kenshoo/pl/intellij/classifier/SourcePackageClassifierTest.java
+++ b/src/test/java/com/kenshoo/pl/intellij/classifier/SourcePackageClassifierTest.java
@@ -1,4 +1,4 @@
-package com.kenshoo.pl.intellij.controller;
+package com.kenshoo.pl.intellij.classifier;
 
 import com.intellij.ide.IdeView;
 import com.intellij.openapi.actionSystem.CommonDataKeys;

--- a/src/test/java/com/kenshoo/pl/intellij/controller/PlEntityWizardActionTest.java
+++ b/src/test/java/com/kenshoo/pl/intellij/controller/PlEntityWizardActionTest.java
@@ -1,17 +1,25 @@
 package com.kenshoo.pl.intellij.controller;
 
+import com.intellij.ide.IdeView;
 import com.intellij.openapi.actionSystem.AnActionEvent;
 import com.intellij.openapi.actionSystem.DataContext;
+import com.intellij.openapi.actionSystem.LangDataKeys;
 import com.intellij.openapi.actionSystem.Presentation;
+import com.intellij.psi.PsiDirectory;
+import com.kenshoo.pl.intellij.classifier.ModuleClassifier;
+import com.kenshoo.pl.intellij.classifier.SourcePackageClassifier;
+import com.kenshoo.pl.intellij.model.Language;
+import com.kenshoo.pl.intellij.view.NewEntityFormWrapper;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
 
+import static com.kenshoo.pl.intellij.model.Language.SCALA;
 import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.assertThat;
-import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.*;
 
 @RunWith(MockitoJUnitRunner.class)
 public class PlEntityWizardActionTest {
@@ -25,8 +33,20 @@ public class PlEntityWizardActionTest {
     @Mock
     private SourcePackageClassifier sourcePackageClassifier;
 
+    @Mock
+    private ModuleClassifier moduleClassifier;
+
+    @Mock
+    private IdeView ideView;
+
+    @Mock
+    private PsiDirectory dir;
+
+    @Mock
+    private NewEntityFormWrapper newEntityFormWrapper;
+
     @InjectMocks
-    private PlEntityWizardAction action;
+    private StubPlEntityWizardAction action;
 
     @Test
     public void updateWhenIsJavaSourcePackageShouldBeEnabledAndVisible() {
@@ -54,5 +74,52 @@ public class PlEntityWizardActionTest {
 
         assertThat("Should be disabled: ", presentation.isEnabled(), is(false));
         assertThat("Should be invisible: ", presentation.isVisible(), is(false));
+    }
+
+    @Test
+    public void actionPerformedWhenIdeViewExistsShouldShowEntityForm() {
+        when(event.getDataContext()).thenReturn(dataContext);
+        when(dataContext.getData(LangDataKeys.IDE_VIEW.getName())).thenReturn(ideView);
+        when(ideView.getOrChooseDirectory()).thenReturn(dir);
+        when(moduleClassifier.determineLanguage(dataContext)).thenReturn(SCALA);
+
+        action.actionPerformed(event);
+
+        verify(newEntityFormWrapper).show();
+
+        assertThat("Incorrect dir: ", action.dir, is(dir));
+        assertThat("Incorrect language: ", action.language, is(SCALA));
+    }
+
+    @Test
+    public void actionPerformedWhenIdeViewDoesNotExistShouldDoNothing() {
+        when(event.getDataContext()).thenReturn(dataContext);
+        when(dataContext.getData(LangDataKeys.IDE_VIEW.getName())).thenReturn(null);
+
+        action.actionPerformed(event);
+
+        verifyNoMoreInteractions(newEntityFormWrapper);
+    }
+
+    private static class StubPlEntityWizardAction extends PlEntityWizardAction {
+
+        private final NewEntityFormWrapper newEntityFormWrapper;
+
+        private PsiDirectory dir;
+        private Language language;
+
+        private StubPlEntityWizardAction(final SourcePackageClassifier sourcePackageClassifier,
+                                         final ModuleClassifier moduleClassifier,
+                                         final NewEntityFormWrapper newEntityFormWrapper) {
+            super(sourcePackageClassifier, moduleClassifier);
+            this.newEntityFormWrapper = newEntityFormWrapper;
+        }
+
+        @Override
+        NewEntityFormWrapper newEntityFormWrapper(final PsiDirectory dir, final Language language) {
+            this.dir = dir;
+            this.language = language;
+            return newEntityFormWrapper;
+        }
     }
 }


### PR DESCRIPTION
- Added Scala support by an **optional** dependency on the Scala plugin (so it should still work for Java projects)
- Added the ability to distinguish between Scala and Java when the form is opened. For now, the form title is the only thing that changes in order to test that it works.

**NOTE** that for checking _availability_ (when to show the menu item) - Scala and Java are **identical** cases, since IntelliJ considers all Scala packages to be Java packages too. Therefore the Wizard `update()` method does not need to change. 
Only when opening the _form_ do we need the ability to distinguish between them - that's why I added a new classifier by _module_ that can do that. It checks for Scala libraries in the module dependencies (that's the only real distinction between the languages).